### PR TITLE
add option to not use default ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,20 @@ a `ignore` property to `package.json`:
 }
 ```
 
+Some files are ignored by default:
+
+```js
+var DEFAULT_IGNORE = [
+  '**/*.min.js',
+  '**/bundle.js',
+  'coverage/**',
+  'node_modules/**',
+  'vendor/**'
+]
+```
+
+You can disable these default ignores by setting `noDefaultIgnore` option to `true`.
+
 ### Hiding Warnings
 
 Since `standard-engine` uses [`eslint`](http://eslint.org/) under-the-hood, you can

--- a/index.js
+++ b/index.js
@@ -132,7 +132,9 @@ Linter.prototype.parseOpts = function (opts) {
 
   if (!opts.ignore) opts.ignore = []
   addIgnore(packageOpts.ignore)
-  addIgnore(DEFAULT_IGNORE)
+  if (!packageOpts.noDefaultIgnore) {
+    addIgnore(DEFAULT_IGNORE)
+  }
 
   addGlobals(packageOpts.globals || packageOpts.global)
   addGlobals(opts.globals || opts.global)


### PR DESCRIPTION
This option is required for project that use the `node_modules` style monorepo (Pouchdb, Cerebraljs).

Without this option the user has no control on default ignores.