### PR TITLE
Allow disabling cache

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,6 +23,7 @@ function Cli (opts) {
       verbose: 'v'
     },
     boolean: [
+      'cache',
       'fix',
       'help',
       'stdin',
@@ -30,11 +31,15 @@ function Cli (opts) {
       'version'
     ],
     string: [
+      'cache-location',
       'global',
       'plugin',
       'parser',
       'env'
-    ]
+    ],
+    default: {
+      'cache': true // when not used, a boolean defaults to false, not undefined
+    }
   })
 
   // Unix convention: Command line argument `-` is a shorthand for `--stdin`
@@ -58,17 +63,19 @@ Usage:
     Paths in a project's root .gitignore file are also automatically ignored.
 
 Flags:
-        --fix       Automatically fix problems
-    -v, --verbose   Show rule names for errors (to ignore specific rules)
-        --version   Show current version
-    -h, --help      Show usage information
+        --fix              Automatically fix problems
+    -v, --verbose          Show rule names for errors (to ignore specific rules)
+        --version          Show current version
+    -h, --help             Show usage information
 
 Flags (advanced):
-        --stdin     Read file text from stdin
-        --global    Declare global variable
-        --plugin    Use custom eslint plugin
-        --env       Use custom eslint environment
-        --parser    Use custom js parser (e.g. babel-eslint)
+        --stdin            Read file text from stdin
+        --global           Declare global variable
+        --plugin           Use custom eslint plugin
+        --env              Use custom eslint environment
+        --parser           Use custom js parser (e.g. babel-eslint)
+        --cache            Only check changed files - default: true
+        --cache-location   Path to the cache file or directory
     `)
     process.exitCode = 0
     return
@@ -85,7 +92,9 @@ Flags (advanced):
     globals: argv.global,
     plugins: argv.plugin,
     envs: argv.env,
-    parser: argv.parser
+    parser: argv.parser,
+    cache: argv.cache,
+    cacheLocation: argv['cache-location']
   }
 
   var stdinText

--- a/index.js
+++ b/index.js
@@ -149,6 +149,9 @@ Linter.prototype.parseOpts = function (opts, usePackageJson) {
 
   setParser(packageOpts.parser || opts.parser)
 
+  setCache()
+  setCacheLocation()
+
   if (self.customParseOpts) {
     var rootDir
     if (usePackageJson) {
@@ -187,6 +190,22 @@ Linter.prototype.parseOpts = function (opts, usePackageJson) {
   function setParser (parser) {
     if (!parser) return
     opts.eslintConfig.parser = parser
+  }
+
+  function setCache () {
+    if (typeof packageOpts.cache !== 'undefined') {
+      opts.eslintConfig.cache = packageOpts.cache
+    } else if (typeof opts.cache !== 'undefined') {
+      opts.eslintConfig.cache = opts.cache
+    }
+  }
+
+  function setCacheLocation () {
+    if (typeof packageOpts.cacheLocation !== 'undefined') {
+      opts.eslintConfig.cacheLocation = packageOpts.cacheLocation
+    } else if (typeof opts.cacheLocation !== 'undefined') {
+      opts.eslintConfig.cacheLocation = opts.cacheLocation
+    }
   }
 
   return opts


### PR DESCRIPTION
This allows to either set the command-line option `--cache=false` or add `cache: false` in `package.json` to disable caching, and change the cache's location with `--cache-location=""` or `cacheLocation: ""` in `package.json`.

The option in `package.json` takes precedence (because that's how it was already defined for the `parser` option).


_Backstory:
We use semistandard at my job. Today one of our projects had suddenly failing builds on CI due to lint errors that did not appear on developers' machines. The cause was an update to semistandard that slightly changed linting rules. However, a simple `rm -rf node_modules && npm install` on developers' machines did not help reveal the issues. After some hair-pulling, we realized those new issues suddenly appear after an unrelated edit is made to a file. That lead to the discovery that ESLint is capable of caching (where it's disabled by default), and that this project hardcodes `cache: true`. We would like to disable caching in our project to minimalize the chance of discrepancy between linting results on developers' machines and CI as speed is not an issue in the project._