### PR TITLE
BREAKING: Add { usePackageJson: false } option, set default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,15 +275,18 @@ be provided:
 
 ```js
 {
-  cwd: '',      // current working directory (default: process.cwd())
-  filename: '', // path of the file containing the text being linted (optional, though some eslint plugins require it)
-  fix: false,   // automatically fix problems
-  globals: [],  // custom global variables to declare
-  plugins: [],  // custom eslint plugins
-  envs: [],     // custom eslint environment
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  cwd: '',              // current working directory (default: process.cwd())
+  filename: '',         // path of file containing the text being linted
+  fix: false,           // automatically fix problems
+  globals: [],          // custom global variables to declare
+  plugins: [],          // custom eslint plugins
+  envs: [],             // custom eslint environment
+  parser: '',           // custom js parser (e.g. babel-eslint)
+  usePackageJson: true  // use options from nearest package.json?
 }
 ```
+
+All options are optional, though some ESLint plugins require the `filename` option.
 
 Additional options may be loaded from a `package.json` if it's found for the current working directory. See below for further details.
 
@@ -320,13 +323,14 @@ Lint the provided `files` globs. An `opts` object may be provided:
 
 ```js
 {
-  ignore: [],   // file globs to ignore (has sane defaults)
-  cwd: '',      // current working directory (default: process.cwd())
-  fix: false,   // automatically fix problems
-  globals: [],  // custom global variables to declare
-  plugins: [],  // custom eslint plugins
-  envs: [],     // custom eslint environment
-  parser: ''    // custom js parser (e.g. babel-eslint)
+  ignore: [],           // file globs to ignore (has sane defaults)
+  cwd: '',              // current working directory (default: process.cwd())
+  fix: false,           // automatically fix problems
+  globals: [],          // custom global variables to declare
+  plugins: [],          // custom eslint plugins
+  envs: [],             // custom eslint environment
+  parser: '',           // custom js parser (e.g. babel-eslint)
+  usePackageJson: true  // use options from nearest package.json?
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -54,10 +54,11 @@ function Linter (opts) {
  * @param {Array.<string>=} opts.plugins  custom eslint plugins
  * @param {Array.<string>=} opts.envs     custom eslint environment
  * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
- * @param {string=} opts.filename         path of the file containing the text being linted
+ * @param {string=} opts.filename         path of file containing the text being linted
+ * @param {boolean=} opts.usePackageJson  use options from nearest package.json? (default: true)
  */
 Linter.prototype.lintTextSync = function (text, opts) {
-  opts = this.parseOpts(opts, false)
+  opts = this.parseOpts(opts)
   return new this.eslint.CLIEngine(opts.eslintConfig).executeOnText(text, opts.filename)
 }
 
@@ -84,12 +85,13 @@ Linter.prototype.lintText = function (text, opts, cb) {
  * @param {Array.<string>=} opts.plugins  custom eslint plugins
  * @param {Array.<string>=} opts.envs     custom eslint environment
  * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
+ * @param {boolean=} opts.usePackageJson  use options from nearest package.json? (default: true)
  * @param {function(Error, Object)} cb    callback
  */
 Linter.prototype.lintFiles = function (files, opts, cb) {
   var self = this
   if (typeof opts === 'function') return self.lintFiles(files, null, opts)
-  opts = self.parseOpts(opts, true)
+  opts = self.parseOpts(opts)
 
   if (typeof files === 'string') files = [ files ]
   if (files.length === 0) files = DEFAULT_PATTERNS
@@ -119,7 +121,7 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
   })
 }
 
-Linter.prototype.parseOpts = function (opts, usePackageJson) {
+Linter.prototype.parseOpts = function (opts) {
   var self = this
 
   if (!opts) opts = {}
@@ -128,6 +130,12 @@ Linter.prototype.parseOpts = function (opts, usePackageJson) {
   opts.eslintConfig.fix = !!opts.fix
 
   if (!opts.cwd) opts.cwd = self.cwd || process.cwd()
+
+  // If no usePackageJson option is given, default to `true`
+  var usePackageJson = opts.usePackageJson != null
+    ? opts.usePackageJson
+    : true
+
   var packageOpts = usePackageJson
     ? pkgConf.sync(self.cmd, { cwd: opts.cwd })
     : {}


### PR DESCRIPTION
1. Add an option { usePackageJson: false } to standard.lintText() that allows enabling/disabling taking package.json settings into account.

2. Change the default back to what it was in 7.0.0, which is to take package.json into account by default. Ignoring package.json settings is a breaking change that should not have been released in 7.1.0.

See: https://github.com/standard/standard-engine/pull/166#issuecomment-366482023