### PR TITLE
Cache directory respects XDG_CACHE_HOME (basedir spec)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var os = require('os')
 var path = require('path')
 var pkgConf = require('pkg-conf')
 
-var HOME_OR_TMP = os.homedir() || os.tmpdir()
+var CACHE_HOME = require('xdg-basedir').cache || os.tmpdir()
 
 var DEFAULT_PATTERNS = [
   '**/*.js',
@@ -39,7 +39,7 @@ function Linter (opts) {
   var majorVersion = (m && m[1]) || '0'
 
   // Example cache location: .standard-v12-cache/
-  var cacheLocation = path.join(HOME_OR_TMP, `.${this.cmd}-v${majorVersion}-cache/`)
+  var cacheLocation = path.join(CACHE_HOME, this.cmd, `v${majorVersion}/`)
 
   this.eslintConfig = Object.assign({
     cache: true,

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ function Linter (opts) {
   var m = opts.version && opts.version.match(/^(\d+)\./)
   var majorVersion = (m && m[1]) || '0'
 
-  // Example cache location: .standard-v12-cache/
+  // Example cache location: ~/.cache/standard/v12/
   var cacheLocation = path.join(CACHE_HOME, this.cmd, `v${majorVersion}/`)
 
   this.eslintConfig = Object.assign({

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "deglob": "^4.0.1",
     "get-stdin": "^7.0.0",
     "minimist": "^1.2.5",
-    "pkg-conf": "^3.1.0"
+    "pkg-conf": "^3.1.0",
+    "xdg-basedir": "^4.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
Instead of setting the cacheLocation to a directory in the user `$HOME`, this PR now respects the [XDG Basedir Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) (specifically the `XDG_CACHE_HOME` environment variable).

**Which issue (if any) does this pull request address?**
fixes https://github.com/standard/standard/issues/1501

**Is there anything you'd like reviewers to focus on?**
The XDG Basedir spec states that `XDG_CACHE_HOME` should be used (if set) to determine where to write cache files. It is recommended and conventional that tools create a self-named directory beneath cache-home for the files to live in. If the `XDG_CACHE_HOME` is empty or unset, a value of `$HOME/.cache` is used. (`TMPDIR` is used if `HOME` is unset/empty) Additionally, to mirror the existing support for storing multiple caches, a subdirectory for each major version is used beneath the linter's cache directory. (`${XDG_CACHE_HOME:-$HOME/.cache}/standard/vX`)

[xdg-basedir](https://www.npmjs.com/package/xdg-basedir) is a package by sindresorhus which derives the appropriate values for the different XDG directories according to the spec (and respecting the fallback values). This package derives these values only once, when required. Because the values are cached, it is non-trivial to write tests to cover the various env-var scenarios. Due to this and the simplicity of the code change, I opted to not add any tests to the existing (simple) suite.

In place of tests, here are the various scenarios covered manually:

1. `XDG_CACHE_HOME` configured to a custom location:

    ```sh
    $ XDG_CACHE_HOME=/my/cache node -p "new require('./').linter({cmd: 'linty', eslint: require('eslint')}).eslintConfig.cacheLocation"
    /my/cache/linty/v0/
    ````

2. `XDG_CACHE_HOME` is unset or empty; (uses the XDG default: `$HOME/.cache/`)

    ```sh
    $ XDG_CACHE_HOME= node -p "new require('./').linter({cmd: 'linty', eslint: require('eslint')}).eslintConfig.cacheLocation"
    /Users/jasonkarns/.cache/linty/v0/
    ```

3. `XDG_CACHE_HOME` is unset or empty _and_ `HOME` is unset or empty; (uses TMPDIR):

    ```sh
    $ TMPDIR=/tempy HOME= XDG_CACHE_HOME= node -p "new require('./').linter({cmd: 'linty', eslint: require('eslint')}).eslintConfig.cacheLocation"
    /tempy/linty/v0/
    ````
