### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function Linter (opts) {
 
   this.eslintConfig = Object.assign({
     cache: true,
-    cacheLocation: cacheLocation,
+    cacheLocation,
     envs: [],
     fix: false,
     globals: [],

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   },
   "scripts": {
     "test": "standard && tape test/clone.js test/api.js"
+  },
+  "engines": {
+    "node": ">=8.10"
   }
 }

--- a/test/api.js
+++ b/test/api.js
@@ -6,7 +6,7 @@ function getStandard () {
   return new Linter({
     cmd: 'pocketlint',
     version: '0.0.0',
-    eslint: eslint,
+    eslint,
     eslintConfig: require('../tmp/standard/options').eslintConfig
   })
 }

--- a/test/api.js
+++ b/test/api.js
@@ -1,5 +1,6 @@
 var eslint = require('eslint')
 var Linter = require('../').linter
+var path = require('path')
 var test = require('tape')
 
 function getStandard () {
@@ -14,7 +15,7 @@ function getStandard () {
 test('api: lintFiles', function (t) {
   t.plan(3)
   var standard = getStandard()
-  standard.lintFiles([], { cwd: '../bin' }, function (err, result) {
+  standard.lintFiles([], { cwd: path.join(__dirname, '../bin') }, function (err, result) {
     t.error(err, 'no error while linting')
     t.equal(typeof result, 'object', 'result is an object')
     t.equal(result.errorCount, 0)

--- a/test/lib/standard-cmd.js
+++ b/test/lib/standard-cmd.js
@@ -4,7 +4,7 @@ var eslint = require('eslint')
 var opts = {
   cmd: 'pocketlint',
   version: '0.0.0',
-  eslint: eslint,
+  eslint,
   eslintConfig: {
     configFile: path.join(__dirname, 'standard.json'),
     useEslintrc: false


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain: lint update

**What changes did you make? (Give an overview)**

I started using object shorthand for properties, that is, I changed `eslint: eslint` to `eslint`.

**Which issue (if any) does this pull request address?**

https://github.com/standard/eslint-config-standard/pull/166

**Is there anything you'd like reviewers to focus on?**

The three lines changed 😅 

-----

Compatibility: This is supported on Node.js >=4, and we are using `Object.assign` which also became available in that version ✅ 
