### PR TITLE
Allow passing in a custom linter to `cli`

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,7 +7,7 @@ var getStdin = require('get-stdin')
 
 function Cli (opts) {
   var Linter = require('../').linter
-  var standard = new Linter(opts)
+  var standard = opts.linter || new Linter(opts)
 
   opts = Object.assign({
     cmd: 'standard-engine',


### PR DESCRIPTION
This allows a downstream project like `tsdocstandard` to subclass the `Linter`

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Allow passing in a custom linter object to `cli()`

**Which issue (if any) does this pull request address?**

**Is there anything you'd like reviewers to focus on?**
