### PR TITLE
[docs] Remove bundle.js from the list of default ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ projects `package.json` file.
 
 ### Ignoring Files
 
-The paths `node_modules/**`, `*.min.js`, `bundle.js`, `coverage/**`, hidden files/folders
+The paths `node_modules/**`, `*.min.js`, `coverage/**`, hidden files/folders
 (beginning with `.`), and all patterns in a project's root `.gitignore` file are
 automatically ignored.
 
@@ -152,7 +152,6 @@ Some files are ignored by default:
 ```js
 var DEFAULT_IGNORE = [
   '**/*.min.js',
-  '**/bundle.js',
   'coverage/**',
   'node_modules/**',
   'vendor/**'

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -53,7 +53,7 @@ Usage:
     If FILES is omitted, all JavaScript source files (*.js, *.jsx, *.mjs, *.cjs)
     in the current working directory are checked, recursively.
 
-    Certain paths (node_modules/, coverage/, vendor/, *.min.js, bundle.js, and
+    Certain paths (node_modules/, coverage/, vendor/, *.min.js, and
     files/folders that begin with '.' like .git/) are automatically ignored.
 
     Paths in a project's root .gitignore file are also automatically ignored.


### PR DESCRIPTION
The documents say that "bundle.js" is ignored by default, but actually it is not (anymore). https://github.com/standard/standard-engine/commit/1319c5b4d6b39eecf909a7072ae92eabe36e0213

**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Removed `bundle.js` from the list of default ignored files in `README.md` and `standard --help`.

**Which issue (if any) does this pull request address?**

https://github.com/standard/standard/issues/743

**Is there anything you'd like reviewers to focus on?**
