### PR TITLE
BREAKING: Use eslint for pattern ignoring; remove deglob

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,13 +147,15 @@ Linter.prototype.parseOpts = function (opts) {
   opts.eslintConfig.cwd = opts.cwd
   opts.eslintConfig.fix = opts.fix
 
-  var packageOpts = opts.usePackageJson
-    ? pkgConf.sync(self.cmd, { cwd: opts.cwd })
-    : {}
+  var packageOpts = {}
+  var rootPath = null
 
-  var rootPath = opts.usePackageJson
-    ? path.dirname(pkgConf.filepath(packageOpts))
-    : null
+  if (opts.usePackageJson || opts.useGitIgnore) {
+    packageOpts = pkgConf.sync(self.cmd, { cwd: opts.cwd })
+    rootPath = path.dirname(pkgConf.filepath(packageOpts))
+  }
+
+  if (!opts.usePackageJson) packageOpts = {}
 
   if (!packageOpts.noDefaultIgnore) {
     addIgnore(DEFAULT_IGNORE)

--- a/index.js
+++ b/index.js
@@ -3,18 +3,18 @@ module.exports.cli = require('./bin/cmd')
 
 module.exports.linter = Linter
 
-var deglob = require('deglob')
 var os = require('os')
 var path = require('path')
 var pkgConf = require('pkg-conf')
+var fs = require('fs')
 
 var CACHE_HOME = require('xdg-basedir').cache || os.tmpdir()
 
-var DEFAULT_PATTERNS = [
-  '**/*.js',
-  '**/*.jsx',
-  '**/*.mjs',
-  '**/*.cjs'
+var DEFAULT_EXTENSIONS = [
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs'
 ]
 
 var DEFAULT_IGNORE = [
@@ -48,8 +48,9 @@ function Linter (opts) {
     envs: [],
     fix: false,
     globals: [],
-    ignore: false,
     plugins: [],
+    ignorePattern: [],
+    extensions: DEFAULT_EXTENSIONS,
     useEslintrc: false
   }, opts.eslintConfig)
 
@@ -109,57 +110,69 @@ Linter.prototype.lintFiles = function (files, opts, cb) {
   opts = self.parseOpts(opts)
 
   if (typeof files === 'string') files = [files]
-  if (files.length === 0) files = DEFAULT_PATTERNS
+  if (files.length === 0) files = ['.']
 
-  var deglobOpts = {
-    ignore: opts.ignore,
-    cwd: opts.cwd,
-    useGitIgnore: true,
-    usePackageJson: false
+  var result
+  try {
+    result = new self.eslint.CLIEngine(opts.eslintConfig).executeOnFiles(files)
+  } catch (err) {
+    return cb(err)
   }
 
-  deglob(files, deglobOpts, function (err, allFiles) {
-    if (err) return cb(err)
+  if (opts.fix) {
+    self.eslint.CLIEngine.outputFixes(result)
+  }
 
-    var result
-    try {
-      result = new self.eslint.CLIEngine(opts.eslintConfig).executeOnFiles(allFiles)
-    } catch (err) {
-      return cb(err)
-    }
-
-    if (opts.fix) {
-      self.eslint.CLIEngine.outputFixes(result)
-    }
-
-    return cb(null, result)
-  })
+  return cb(null, result)
 }
 
 Linter.prototype.parseOpts = function (opts) {
   var self = this
 
-  if (!opts) opts = {}
-  opts = Object.assign({}, opts)
-  opts.eslintConfig = Object.assign({}, self.eslintConfig)
-  opts.eslintConfig.fix = !!opts.fix
+  opts = {
+    eslintConfig: { ...self.eslintConfig },
+    usePackageJson: true,
+    useGitIgnore: true,
+    gitIgnoreFile: ['.gitignore', '.git/info/exclude'],
+    cwd: self.cwd,
+    fix: false,
+    ignore: [],
+    ...opts
+  }
 
-  if (!opts.cwd) opts.cwd = self.cwd
+  if (!Array.isArray(opts.gitIgnoreFile)) {
+    opts.gitIgnoreFile = [opts.gitIgnoreFile]
+  }
+
   opts.eslintConfig.cwd = opts.cwd
+  opts.eslintConfig.fix = opts.fix
 
-  // If no usePackageJson option is given, default to `true`
-  var usePackageJson = opts.usePackageJson != null
-    ? opts.usePackageJson
-    : true
-
-  var packageOpts = usePackageJson
+  var packageOpts = opts.usePackageJson
     ? pkgConf.sync(self.cmd, { cwd: opts.cwd })
     : {}
 
-  if (!opts.ignore) opts.ignore = []
-  addIgnore(packageOpts.ignore)
+  var rootPath = opts.usePackageJson
+    ? path.dirname(pkgConf.filepath(packageOpts))
+    : null
+
   if (!packageOpts.noDefaultIgnore) {
     addIgnore(DEFAULT_IGNORE)
+  }
+  addIgnore(packageOpts.ignore)
+
+  if (opts.useGitIgnore) {
+    opts.gitIgnoreFile
+      .map(gitIgnoreFile => {
+        try {
+          return fs.readFileSync(path.join(rootPath, gitIgnoreFile), 'utf8')
+        } catch (err) {
+          return null
+        }
+      })
+      .filter(Boolean)
+      .forEach(gitignore => {
+        addIgnore(gitignore.split(/\r?\n/))
+      })
   }
 
   addGlobals(packageOpts.globals || packageOpts.global)
@@ -175,7 +188,7 @@ Linter.prototype.parseOpts = function (opts) {
 
   if (self.customParseOpts) {
     var rootDir
-    if (usePackageJson) {
+    if (opts.usePackageJson) {
       var filePath = pkgConf.filepath(packageOpts)
       rootDir = filePath ? path.dirname(filePath) : opts.cwd
     } else {
@@ -186,7 +199,7 @@ Linter.prototype.parseOpts = function (opts) {
 
   function addIgnore (ignore) {
     if (!ignore) return
-    opts.ignore = opts.ignore.concat(ignore)
+    opts.eslintConfig.ignorePattern = opts.eslintConfig.ignorePattern.concat(ignore)
   }
 
   function addGlobals (globals) {

--- a/package.json
+++ b/package.json
@@ -45,18 +45,18 @@
   },
   "devDependencies": {
     "babel-eslint": "^10.1.0",
-    "cross-spawn": "^7.0.2",
+    "cross-spawn": "^7.0.3",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-config-standard-jsx": "^8.1.0",
-    "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-standard": "^4.0.2",
     "mkdirp": "^0.5.5",
     "standard": "^14.3.3",
-    "tape": "^5.0.0"
+    "tape": "^5.0.1"
   },
   "engines": {
     "node": ">=8.10"

--- a/package.json
+++ b/package.json
@@ -46,16 +46,15 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "cross-spawn": "^7.0.3",
-    "eslint": "^6.8.0",
-    "eslint-config-standard": "^14.1.1",
-    "eslint-config-standard-jsx": "^8.1.0",
+    "eslint": "^7.12.1",
+    "eslint-config-standard": "^15.0.1",
+    "eslint-config-standard-jsx": "^9.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-standard": "^4.0.2",
-    "mkdirp": "^0.5.5",
-    "standard": "^14.3.3",
+    "standard": "^15.0.1",
     "tape": "^5.0.1"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "test": "standard && tape test/clone.js test/api.js"
   },
   "dependencies": {
-    "deglob": "^4.0.1",
     "get-stdin": "^8.0.0",
     "minimist": "^1.2.5",
     "pkg-conf": "^3.1.0",

--- a/test/clone.js
+++ b/test/clone.js
@@ -2,7 +2,6 @@
 
 var crossSpawn = require('cross-spawn')
 var fs = require('fs')
-var mkdirp = require('mkdirp')
 var path = require('path')
 var test = require('tape')
 
@@ -18,7 +17,7 @@ const pkg = {
 test('test `standard` repo', function (t) {
   t.plan(1)
 
-  mkdirp.sync(TMP)
+  fs.mkdirSync(TMP, { recursive: true })
 
   var name = pkg.name
   var url = pkg.repo + '.git'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

BREAKING: Use eslint for file ignoring; remove deblog

Ignore patterns should follow the .gitignore format rather than the `glob` pattern. So, you can use dir/ instead of dir/** now. There may be subtle differences in behavior.

**Which issue (if any) does this pull request address?**

Fixes: #226
Fixes: https://github.com/standard/standard/issues/1333
Fixes: https://github.com/standard/standard/issues/1117
Fixes: https://github.com/standard/standard/issues/1023
Fixes: https://github.com/standard/standard/issues/1384

**Is there anything you'd like reviewers to focus on?**
