### PR TITLE
feat: make `--verbose` the default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,19 +174,6 @@ var DEFAULT_IGNORE = [
 
 You can disable these default ignores by setting the `noDefaultIgnore` option to `true`.
 
-### Hiding Warnings
-
-Since `standard-engine` uses [`eslint`](http://eslint.org/) under-the-hood, you can
-hide warnings as you normally would if you used `eslint` directly.
-
-To get verbose output (so you can find the particular rule name to ignore), run:
-
-```bash
-$ pocketlint --verbose
-Error: Live by your own standards!
-  routes/error.js:20:36: 'file' was used before it was defined. (no-use-before-define)
-```
-
 Disable **all rules** on a specific line:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ var DEFAULT_IGNORE = [
 
 You can disable these default ignores by setting the `noDefaultIgnore` option to `true`.
 
+### Hiding Warnings
+
+Since `standard-engine` uses [`eslint`](http://eslint.org/) under-the-hood, you can hide warnings as you normally would if you used `eslint` directly.
+
 Disable **all rules** on a specific line:
 
 ```js

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -20,14 +20,12 @@ function Cli (opts) {
       global: 'globals',
       plugin: 'plugins',
       env: 'envs',
-      help: 'h',
-      verbose: 'v'
+      help: 'h'
     },
     boolean: [
       'fix',
       'help',
       'stdin',
-      'verbose',
       'version'
     ],
     string: [
@@ -61,7 +59,6 @@ Usage:
 
 Flags:
         --fix       Automatically fix problems
-    -v, --verbose   Show rule names for errors (to ignore specific rules)
         --version   Show current version
     -h, --help      Show usage information
 
@@ -161,8 +158,8 @@ Flags (advanced):
           message.line || 0,
           message.column || 0,
           message.message,
-          argv.verbose ? ' (' + message.ruleId + ')' : '',
-          argv.verbose && message.severity === 1 ? ' (warning)' : ''
+          ' (' + message.ruleId + ')',
+          message.severity === 1 ? ' (warning)' : ''
         )
       })
     })

--- a/test/clone.js
+++ b/test/clone.js
@@ -50,7 +50,7 @@ test('test `standard` repo', function (t) {
     }
 
     function runStandard () {
-      const args = ['--verbose']
+      const args = []
       if (pkg.args) args.push.apply(args, pkg.args)
       spawn(STANDARD, args, { cwd: folder }, function (err) {
         const str = name + ' (' + pkg.repo + ')'


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: Make `--verbose` the default 

As discussed in https://github.com/standard/standard/issues/1585
This PR delete the `--verbose` flag.