### PR TITLE
ci: add dependabot + change Travis to GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# For more information see: https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
+      fail-fast: false
 
     steps:
       - name: 'Checkout Project'
@@ -25,12 +26,13 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: 'Cache dependencies'
-        uses: 'actions/cache@v2'
+      - name: 'Cache Node dependencies'
+        uses: 'actions/cache@v2.1.4'
         with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+          path: '~/.npm'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
       - name: 'Install Dependencies'
         run: 'npm install'

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,39 @@
+name: 'tests'
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+      - name: 'Checkout Project'
+        uses: 'actions/checkout@v2'
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: 'actions/setup-node@v2.1.3'
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: 'Cache dependencies'
+        uses: 'actions/cache@v2'
+        with:
+          path: |
+            **/node_modules
+          key: ${{ runner.os }}-${{ hashFiles('**/package.json') }}
+
+      - name: 'Install Dependencies'
+        run: 'npm install'
+
+      - name: 'Run Tests'
+        run: 'npm test'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-cache:
-  npm: false
-language: node_js
-node_js:
-  - 10
-  - 12
-  - 14

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# standard-engine [![travis][travis-image]][travis-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
+# standard-engine [![Tests CI][ci-image]][ci-url] [![npm][npm-image]][npm-url] [![downloads][downloads-image]][downloads-url] [![javascript style guide][standard-image]][standard-url]
 
-[travis-image]: https://img.shields.io/travis/standard/standard-engine/master.svg
-[travis-url]: https://travis-ci.org/standard/standard-engine
+[ci-image]: https://github.com/standard/standard-engine/workflows/tests/badge.svg?branch=master
+[ci-url]: https://github.com/standard/standard-engine/actions?query=workflow%3A%22tests%22
 [npm-image]: https://img.shields.io/npm/v/standard-engine.svg
 [npm-url]: https://npmjs.org/package/standard-engine
 [downloads-image]: https://img.shields.io/npm/dm/standard-engine.svg


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [ ] Documentation update
- [ ] Bug fix
- [ ] New feature
- [x] Other, please explain: Continuous Integration files changes

**What changes did you make? (Give an overview)**

- Add `.github/dependabot.yml`
- Add `.github/workflows/nodejs.yml`
- Delete `.travis.yml`
- Update `README` with the new badge

**Is there anything you'd like reviewers to focus on?**

We should remove the stale branches from the old Greenkeeper bot https://github.com/standard/standard-engine/branches/stale once this has been merged.