### PR TITLE
Add more JSDoc annotations + validate them and refactor to make them clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ install `babel-eslint` globally with `npm install babel-eslint -g`.
 
 ### Custom options
 
-You can provide a `parseOpts()` function in the `options.js` exports:
+You can provide a `resolveEslintConfig()` function in the `options.js` exports:
 
 ```js
 var eslint = require('eslint')
@@ -285,24 +285,16 @@ module.exports = {
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')
   },
-  parseOpts: function (opts, packageOpts, rootDir) {
-    // provide implementation here, then return the opts object (or a new one)
-    return opts
+  resolveEslintConfig: function (eslintConfig, opts, packageOpts, rootDir) {
+    // provide implementation here, then return the eslintConfig object (or a new one)
+    return eslintConfig
   }
 }
 ```
 
-This function is called with the current options object (`opts`), any options extracted from the project's `package.json` (`packageOpts`), and the directory that contained that `package.json` file (`rootDir`, equivalent to `opts.cwd` if no file was found).
+This function is called with the current ESLint config (the options passed to [ESLint's `CLIEngine`](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)), the options object (`opts`), any options extracted from the project's `package.json` (`packageOpts`), and the directory that contained that `package.json` file (`rootDir`, equivalent to `opts.cwd` if no file was found).
 
-Modify and return `opts`, or return a new object with the options that are to be used.
-
-The following options are provided in the `opts` object, and must be on the returned object:
-
-- `ignore`: array of file patterns (in `.gitignore` format) to ignore
-- `cwd`: string, the current working directory
-- `fix`: boolean, whether to automatically fix problems
-- `eslintConfig`: object, the options passed to [ESLint's `CLIEngine`](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)
-
+Modify and return `eslintConfig`, or return a new object with the eslint config to be used.
 ## API Usage
 
 ### `engine.lintText(text, [opts], callback)`

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ module.exports = {
 This function is called with the current ESLint config (the options passed to [ESLint's `CLIEngine`](http://eslint.org/docs/developer-guide/nodejs-api#cliengine)), the options object (`opts`), any options extracted from the project's `package.json` (`packageOpts`), and the directory that contained that `package.json` file (`rootDir`, equivalent to `opts.cwd` if no file was found).
 
 Modify and return `eslintConfig`, or return a new object with the eslint config to be used.
+
 ## API Usage
 
 ### `engine.lintText(text, [opts], callback)`

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -199,7 +199,7 @@ Flags (advanced):
    * Print lint errors to stdout -- this is expected output from `standard-engine`.
    * Note: When fixing code from stdin (`standard --stdin --fix`), the transformed
    * code is printed to stdout, so print lint errors to stderr in this case.
-   * @type {(message?: any, ...optionalParams: any[]) => void}
+   * @type {typeof console.log}
    */
   function log (...args) {
     if (argv.stdin && argv.fix) {

--- a/index.js
+++ b/index.js
@@ -5,36 +5,41 @@ module.exports.linter = Linter
 
 const os = require('os')
 const path = require('path')
-const pkgConf = require('pkg-conf')
-const fs = require('fs')
 
 const CACHE_HOME = require('xdg-basedir').cache || os.tmpdir()
 
-const DEFAULT_EXTENSIONS = [
-  '.js',
-  '.jsx',
-  '.mjs',
-  '.cjs'
-]
+const { resolveEslintConfig } = require('./lib/resolve-eslint-config')
 
-const DEFAULT_IGNORE = [
-  '**/*.min.js',
-  'coverage/**',
-  'node_modules/**',
-  'vendor/**'
-]
+/** @typedef {ConstructorParameters<typeof import('eslint').CLIEngine>[0]} CLIEngineOptions */
+/** @typedef {Omit<import('./lib/resolve-eslint-config').ResolveOptions, 'cmd'|'cwd'>} BaseLintOptions */
+/** @typedef {(err: Error|null, result?: import('eslint').CLIEngine.LintReport) => void} LinterCallback */
 
+/**
+ * @typedef LinterOptions
+ * @property {string} cmd
+ * @property {import('eslint')} eslint
+ * @property {string} [cwd]
+ * @property {CLIEngineOptions} [eslintConfig]
+ * @property {import('./lib/resolve-eslint-config').CustomEslintConfigResolver} [resolveEslintConfig]
+ * @property {string} [version]
+ */
+
+/**
+ * @param {LinterOptions} opts
+ */
 function Linter (opts) {
   if (!(this instanceof Linter)) return new Linter(opts)
-  if (!opts) opts = {}
 
-  if (!opts.cmd) throw new Error('opts.cmd option is required')
+  if (!opts || !opts.cmd) throw new Error('opts.cmd option is required')
   if (!opts.eslint) throw new Error('opts.eslint option is required')
 
+  /** @type {string} */
   this.cmd = opts.cmd
+  /** @type {import('eslint')} */
   this.eslint = opts.eslint
+  /** @type {string} */
   this.cwd = opts.cwd || process.cwd()
-  this.customParseOpts = opts.parseOpts
+  this.customEslintConfigResolver = opts.resolveEslintConfig
 
   const m = opts.version && opts.version.match(/^(\d+)\./)
   const majorVersion = (m && m[1]) || '0'
@@ -42,7 +47,8 @@ function Linter (opts) {
   // Example cache location: ~/.cache/standard/v12/
   const cacheLocation = path.join(CACHE_HOME, this.cmd, `v${majorVersion}/`)
 
-  this.eslintConfig = Object.assign({
+  /** @type {CLIEngineOptions} */
+  this.eslintConfig = {
     cache: true,
     cacheLocation,
     envs: [],
@@ -51,8 +57,9 @@ function Linter (opts) {
     plugins: [],
     ignorePattern: [],
     extensions: [],
-    useEslintrc: false
-  }, opts.eslintConfig)
+    useEslintrc: false,
+    ...(opts.eslintConfig || {})
+  }
 
   if (this.eslintConfig.configFile != null) {
     this.eslintConfig.resolvePluginsRelativeTo =
@@ -63,23 +70,28 @@ function Linter (opts) {
 /**
  * Lint text to enforce JavaScript Style.
  *
- * @param {string} text                   file text to lint
- * @param {Object=} opts                  options object
- * @param {boolean=} opts.fix             automatically fix problems
- * @param {Array.<string>=} opts.globals  custom global variables to declare
- * @param {Array.<string>=} opts.plugins  custom eslint plugins
- * @param {Array.<string>=} opts.envs     custom eslint environment
- * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
- * @param {string=} opts.filename         path of file containing the text being linted
- * @param {boolean=} opts.usePackageJson  use options from nearest package.json? (default: true)
+ * @param {string} text file text to lint
+ * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
+ * @returns {import('eslint').CLIEngine.LintReport}
  */
 Linter.prototype.lintTextSync = function (text, opts) {
-  opts = this.parseOpts(opts)
-  return new this.eslint.CLIEngine(opts.eslintConfig).executeOnText(text, opts.filename)
+  const eslintConfig = this.resolveEslintConfig(opts)
+  const engine = new this.eslint.CLIEngine(eslintConfig)
+  return engine.executeOnText(text, (opts || {}).filename)
 }
 
+/**
+ * Lint text to enforce JavaScript Style.
+ *
+ * @param {string} text file text to lint
+ * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
+ * @param {LinterCallback} [cb]
+ * @returns {void}
+ */
 Linter.prototype.lintText = function (text, opts, cb) {
-  if (typeof opts === 'function') return this.lintText(text, null, opts)
+  if (typeof opts === 'function') return this.lintText(text, undefined, opts)
+  if (!cb) throw new Error('callback is required')
+
   let result
   try {
     result = this.lintTextSync(text, opts)
@@ -93,156 +105,47 @@ Linter.prototype.lintText = function (text, opts, cb) {
  * Lint files to enforce JavaScript Style.
  *
  * @param {Array.<string>} files          file globs to lint
- * @param {Object=} opts                  options object
- * @param {Array.<string>=} opts.ignore   file globs to ignore (has sane defaults)
- * @param {string=} opts.cwd              current working directory (default: process.cwd())
- * @param {boolean=} opts.fix             automatically fix problems
- * @param {Array.<string>=} opts.globals  custom global variables to declare
- * @param {Array.<string>=} opts.plugins  custom eslint plugins
- * @param {Array.<string>=} opts.envs     custom eslint environment
- * @param {string=} opts.parser           custom js parser (e.g. babel-eslint)
- * @param {boolean=} opts.usePackageJson  use options from nearest package.json? (default: true)
- * @param {function(Error, Object)} cb    callback
+ * @param {BaseLintOptions & { cwd?: string }} [opts] base options + file globs to ignore (has sane defaults) + current working directory (default: process.cwd())
+ * @param {LinterCallback} [cb]
+ * @returns {void}
  */
 Linter.prototype.lintFiles = function (files, opts, cb) {
-  const self = this
-  if (typeof opts === 'function') return self.lintFiles(files, null, opts)
-  opts = self.parseOpts(opts)
+  if (typeof opts === 'function') return this.lintFiles(files, undefined, opts)
+  if (!cb) throw new Error('callback is required')
+
+  const eslintConfig = this.resolveEslintConfig(opts)
 
   if (typeof files === 'string') files = [files]
   if (files.length === 0) files = ['.']
 
   let result
   try {
-    result = new self.eslint.CLIEngine(opts.eslintConfig).executeOnFiles(files)
+    result = new this.eslint.CLIEngine(eslintConfig).executeOnFiles(files)
   } catch (err) {
     return cb(err)
   }
 
-  if (opts.fix) {
-    self.eslint.CLIEngine.outputFixes(result)
+  if (eslintConfig.fix) {
+    this.eslint.CLIEngine.outputFixes(result)
   }
 
   return cb(null, result)
 }
 
-Linter.prototype.parseOpts = function (opts) {
-  const self = this
+/**
+ * @param {BaseLintOptions & { cwd?: string }} [opts]
+ * @returns {CLIEngineOptions}
+ */
+Linter.prototype.resolveEslintConfig = function (opts) {
+  const eslintConfig = resolveEslintConfig(
+    {
+      cwd: this.cwd,
+      ...opts,
+      cmd: this.cmd
+    },
+    this.eslintConfig,
+    this.customEslintConfigResolver
+  )
 
-  opts = {
-    eslintConfig: { ...self.eslintConfig },
-    usePackageJson: true,
-    useGitIgnore: true,
-    gitIgnoreFile: ['.gitignore', '.git/info/exclude'],
-    cwd: self.cwd,
-    fix: false,
-    ignore: [],
-    extensions: [],
-    ...opts
-  }
-
-  if (!Array.isArray(opts.gitIgnoreFile)) {
-    opts.gitIgnoreFile = [opts.gitIgnoreFile]
-  }
-
-  opts.eslintConfig.cwd = opts.cwd
-  opts.eslintConfig.fix = opts.fix
-
-  let packageOpts = {}
-  let rootPath = null
-
-  if (opts.usePackageJson || opts.useGitIgnore) {
-    packageOpts = pkgConf.sync(self.cmd, { cwd: opts.cwd })
-    const packageJsonPath = pkgConf.filepath(packageOpts)
-    if (packageJsonPath) rootPath = path.dirname(packageJsonPath)
-  }
-
-  if (!opts.usePackageJson) packageOpts = {}
-
-  addIgnore(packageOpts.ignore)
-  addIgnore(opts.ignore)
-
-  if (!packageOpts.noDefaultIgnore && !opts.noDefaultIgnore) {
-    addIgnore(DEFAULT_IGNORE)
-  }
-
-  addExtensions(packageOpts.extensions)
-  addExtensions(opts.extensions)
-
-  if (!packageOpts.noDefaultExtensions && !opts.noDefaultExtensions) {
-    addExtensions(DEFAULT_EXTENSIONS)
-  }
-
-  if (opts.useGitIgnore && rootPath) {
-    opts.gitIgnoreFile
-      .map(gitIgnoreFile => {
-        try {
-          return fs.readFileSync(path.join(rootPath, gitIgnoreFile), 'utf8')
-        } catch (err) {
-          return null
-        }
-      })
-      .filter(Boolean)
-      .forEach(gitignore => {
-        addIgnore(gitignore.split(/\r?\n/))
-      })
-  }
-
-  addGlobals(packageOpts.globals || packageOpts.global)
-  addGlobals(opts.globals || opts.global)
-
-  addPlugins(packageOpts.plugins || packageOpts.plugin)
-  addPlugins(opts.plugins || opts.plugin)
-
-  addEnvs(packageOpts.envs || packageOpts.env)
-  addEnvs(opts.envs || opts.env)
-
-  setParser(packageOpts.parser || opts.parser)
-
-  if (self.customParseOpts) {
-    let rootDir
-    if (opts.usePackageJson) {
-      const filePath = pkgConf.filepath(packageOpts)
-      rootDir = filePath ? path.dirname(filePath) : opts.cwd
-    } else {
-      rootDir = opts.cwd
-    }
-    opts = self.customParseOpts(opts, packageOpts, rootDir)
-  }
-
-  function addExtensions (extensions) {
-    if (!extensions) return
-    opts.eslintConfig.extensions = opts.eslintConfig.extensions.concat(extensions)
-  }
-
-  function addIgnore (ignore) {
-    if (!ignore) return
-    opts.eslintConfig.ignorePattern = opts.eslintConfig.ignorePattern.concat(ignore)
-  }
-
-  function addGlobals (globals) {
-    if (!globals) return
-    opts.eslintConfig.globals = self.eslintConfig.globals.concat(globals)
-  }
-
-  function addPlugins (plugins) {
-    if (!plugins) return
-    opts.eslintConfig.plugins = self.eslintConfig.plugins.concat(plugins)
-  }
-
-  function addEnvs (envs) {
-    if (!envs) return
-    if (!Array.isArray(envs) && typeof envs !== 'string') {
-      // envs can be an object in `package.json`
-      envs = Object.keys(envs).filter(function (env) { return envs[env] })
-    }
-    opts.eslintConfig.envs = self.eslintConfig.envs.concat(envs)
-  }
-
-  function setParser (parser) {
-    if (!parser) return
-    opts.eslintConfig.parser = parser
-  }
-
-  return opts
+  return eslintConfig
 }

--- a/lib/resolve-eslint-config.js
+++ b/lib/resolve-eslint-config.js
@@ -56,7 +56,6 @@ const addIgnore = (eslintConfig, ignore) => {
   if (typeof eslintConfig.ignorePattern === 'string') {
     eslintConfig.ignorePattern = [eslintConfig.ignorePattern]
   }
-  // FIXME: This can be either string or string[]?
   eslintConfig.ignorePattern = (eslintConfig.ignorePattern || []).concat(ignore)
 }
 
@@ -146,9 +145,7 @@ const setParser = (eslintConfig, parser) => {
 const resolveEslintConfig = function (rawOpts, baseEslintConfig, customEslintConfigResolver) {
   const opts = {
     usePackageJson: true,
-    // TODO: Document
     useGitIgnore: true,
-    // TODO: Document
     gitIgnoreFile: ['.gitignore', '.git/info/exclude'],
     ...rawOpts
   }
@@ -174,7 +171,6 @@ const resolveEslintConfig = function (rawOpts, baseEslintConfig, customEslintCon
   addIgnore(eslintConfig, ensureStringArrayValue(packageOpts.ignore))
   addIgnore(eslintConfig, opts.ignore)
 
-  // TODO: Document noDefaultIgnore
   if (!packageOpts.noDefaultIgnore && !opts.noDefaultIgnore) {
     addIgnore(eslintConfig, DEFAULT_IGNORE)
   }
@@ -182,7 +178,6 @@ const resolveEslintConfig = function (rawOpts, baseEslintConfig, customEslintCon
   addExtensions(eslintConfig, ensureStringArrayValue(packageOpts.extensions))
   addExtensions(eslintConfig, opts.extensions)
 
-  // TODO: Document noDefaultExtensions
   if (!packageOpts.noDefaultExtensions && !opts.noDefaultExtensions) {
     addExtensions(eslintConfig, DEFAULT_EXTENSIONS)
   }
@@ -203,15 +198,12 @@ const resolveEslintConfig = function (rawOpts, baseEslintConfig, customEslintCon
   }
 
   addGlobals(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.globals || packageOpts.global))
-  // TODO: Document
   addGlobals(eslintConfig, baseEslintConfig, opts.globals || opts.global)
 
   addPlugins(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.plugins || packageOpts.plugin))
-  // TODO: Document
   addPlugins(eslintConfig, baseEslintConfig, opts.plugins || opts.plugin)
 
   addEnvs(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.envs || packageOpts.env))
-  // TODO: Document
   addEnvs(eslintConfig, baseEslintConfig, opts.envs || opts.env)
 
   setParser(eslintConfig, typeof packageOpts.parser === 'string' ? packageOpts.parser : opts.parser)

--- a/lib/resolve-eslint-config.js
+++ b/lib/resolve-eslint-config.js
@@ -1,0 +1,233 @@
+/*! standard-engine. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+
+const fs = require('fs')
+const path = require('path')
+
+const pkgConf = require('pkg-conf')
+
+/** @typedef {import('../').CLIEngineOptions} CLIEngineOptions */
+
+const DEFAULT_EXTENSIONS = [
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs'
+]
+
+const DEFAULT_IGNORE = [
+  '**/*.min.js',
+  'coverage/**',
+  'node_modules/**',
+  'vendor/**'
+]
+
+/**
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+const ensureStringArrayValue = (value) => {
+  if (!Array.isArray(value)) return []
+
+  /** @type {string[]} */
+  const result = []
+
+  for (const item of value) {
+    if (typeof item === 'string') result.push(item)
+  }
+
+  return result
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {string|string[]} [extensions]
+ */
+const addExtensions = (eslintConfig, extensions) => {
+  if (!extensions) return
+  eslintConfig.extensions = (eslintConfig.extensions || []).concat(extensions)
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {string|string[]} [ignore]
+ */
+const addIgnore = (eslintConfig, ignore) => {
+  if (!ignore) return
+  if (typeof eslintConfig.ignorePattern === 'string') {
+    eslintConfig.ignorePattern = [eslintConfig.ignorePattern]
+  }
+  // FIXME: This can be either string or string[]?
+  eslintConfig.ignorePattern = (eslintConfig.ignorePattern || []).concat(ignore)
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {CLIEngineOptions} baseEslintConfig
+ * @param {string|string[]} [globals]
+ */
+const addGlobals = (eslintConfig, baseEslintConfig, globals) => {
+  if (!globals) return
+  eslintConfig.globals = (baseEslintConfig.globals || []).concat(globals)
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {CLIEngineOptions} baseEslintConfig
+ * @param {string|string[]} [plugins]
+ */
+const addPlugins = (eslintConfig, baseEslintConfig, plugins) => {
+  if (!plugins) return
+  eslintConfig.plugins = (baseEslintConfig.plugins || []).concat(plugins)
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {CLIEngineOptions} baseEslintConfig
+ * @param {string|string[]|{[key: string]: string}} [envs]
+ */
+const addEnvs = (eslintConfig, baseEslintConfig, envs) => {
+  if (!envs) return
+  if (!Array.isArray(envs) && typeof envs !== 'string') {
+    // envs can be an object in `package.json`
+    const envsObj = envs
+    envs = []
+    for (const key in envsObj) {
+      const value = envsObj[key]
+      if (value) envs.push(value)
+    }
+  }
+  eslintConfig.envs = (baseEslintConfig.envs || []).concat(envs)
+}
+
+/**
+ * @param {CLIEngineOptions} eslintConfig
+ * @param {string} [parser]
+ */
+const setParser = (eslintConfig, parser) => {
+  if (!parser) return
+  eslintConfig.parser = parser
+}
+
+/**
+ * @typedef ResolveOptions
+ * @property {string} cmd
+ * @property {string} cwd
+ * @property {boolean} [fix]                automatically fix problems
+ * @property {string[]|string} [ignore]
+ * @property {string[]|string} [extensions]
+ * @property {string[]|string} [globals]    custom global variables to declare
+ * @property {string[]|string} [global]
+ * @property {string[]|string} [plugins]    custom eslint plugins
+ * @property {string[]|string} [plugin]
+ * @property {string[]|string} [envs]       custom eslint environment
+ * @property {string[]|string} [env]
+ * @property {string} [parser]              custom js parser (e.g. babel-eslint)
+ * @property {boolean} [useGitIgnore]       use .gitignore? (default: true)
+ * @property {boolean} [usePackageJson]     use options from nearest package.json? (default: true)
+ * @property {boolean} [noDefaultIgnore]
+ * @property {boolean} [noDefaultExtensions]
+ */
+
+/**
+ * @callback CustomEslintConfigResolver
+ * @param {Readonly<CLIEngineOptions>} eslintConfig
+ * @param {Readonly<ResolveOptions>} opts
+ * @param {import('pkg-conf').Config} packageOpts
+ * @param {string} rootDir
+ * @returns {CLIEngineOptions}
+ */
+
+/**
+ * @param {Readonly<ResolveOptions>} rawOpts
+ * @param {Readonly<CLIEngineOptions>} baseEslintConfig
+ * @param {CustomEslintConfigResolver} [customEslintConfigResolver]
+ * @returns {CLIEngineOptions}
+ */
+const resolveEslintConfig = function (rawOpts, baseEslintConfig, customEslintConfigResolver) {
+  const opts = {
+    usePackageJson: true,
+    // TODO: Document
+    useGitIgnore: true,
+    // TODO: Document
+    gitIgnoreFile: ['.gitignore', '.git/info/exclude'],
+    ...rawOpts
+  }
+
+  const eslintConfig = {
+    ...baseEslintConfig,
+    cwd: opts.cwd,
+    fix: !!opts.fix
+  }
+
+  /** @type {import('pkg-conf').Config} */
+  let packageOpts = {}
+  let rootPath = ''
+
+  if (opts.usePackageJson || opts.useGitIgnore) {
+    packageOpts = pkgConf.sync(opts.cmd, { cwd: opts.cwd })
+    const packageJsonPath = pkgConf.filepath(packageOpts)
+    if (packageJsonPath) rootPath = path.dirname(packageJsonPath)
+  }
+
+  if (!opts.usePackageJson) packageOpts = {}
+
+  addIgnore(eslintConfig, ensureStringArrayValue(packageOpts.ignore))
+  addIgnore(eslintConfig, opts.ignore)
+
+  // TODO: Document noDefaultIgnore
+  if (!packageOpts.noDefaultIgnore && !opts.noDefaultIgnore) {
+    addIgnore(eslintConfig, DEFAULT_IGNORE)
+  }
+
+  addExtensions(eslintConfig, ensureStringArrayValue(packageOpts.extensions))
+  addExtensions(eslintConfig, opts.extensions)
+
+  // TODO: Document noDefaultExtensions
+  if (!packageOpts.noDefaultExtensions && !opts.noDefaultExtensions) {
+    addExtensions(eslintConfig, DEFAULT_EXTENSIONS)
+  }
+
+  if (opts.useGitIgnore && rootPath !== '') {
+    (Array.isArray(opts.gitIgnoreFile) ? opts.gitIgnoreFile : [opts.gitIgnoreFile])
+      .map(gitIgnoreFile => {
+        try {
+          return fs.readFileSync(path.join(rootPath, gitIgnoreFile), 'utf8')
+        } catch (err) {
+          return null
+        }
+      })
+      .filter(Boolean)
+      .forEach(gitignore => {
+        gitignore && addIgnore(eslintConfig, gitignore.split(/\r?\n/))
+      })
+  }
+
+  addGlobals(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.globals || packageOpts.global))
+  // TODO: Document
+  addGlobals(eslintConfig, baseEslintConfig, opts.globals || opts.global)
+
+  addPlugins(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.plugins || packageOpts.plugin))
+  // TODO: Document
+  addPlugins(eslintConfig, baseEslintConfig, opts.plugins || opts.plugin)
+
+  addEnvs(eslintConfig, baseEslintConfig, ensureStringArrayValue(packageOpts.envs || packageOpts.env))
+  // TODO: Document
+  addEnvs(eslintConfig, baseEslintConfig, opts.envs || opts.env)
+
+  setParser(eslintConfig, typeof packageOpts.parser === 'string' ? packageOpts.parser : opts.parser)
+
+  if (customEslintConfigResolver) {
+    let rootDir
+    if (opts.usePackageJson) {
+      const filePath = pkgConf.filepath(packageOpts)
+      rootDir = filePath ? path.dirname(filePath) : opts.cwd
+    } else {
+      rootDir = opts.cwd
+    }
+    return customEslintConfigResolver(eslintConfig, opts, packageOpts, rootDir)
+  } else {
+    return eslintConfig
+  }
+}
+
+module.exports = { resolveEslintConfig }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://feross.org"
   },
   "scripts": {
-    "test": "standard && tape test/clone.js test/api.js"
+    "test": "standard && tape test/clone.js test/api.js && tsc"
   },
   "dependencies": {
     "get-stdin": "^8.0.0",
@@ -44,6 +44,10 @@
     "xdg-basedir": "^4.0.0"
   },
   "devDependencies": {
+    "@tsconfig/node10": "^1.0.8",
+    "@types/eslint": "^7.28.0",
+    "@types/minimist": "^1.2.2",
+    "@types/node": "^10.17.60",
     "cross-spawn": "^7.0.3",
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.0",
@@ -53,7 +57,8 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-react": "^7.21.5",
     "standard": "*",
-    "tape": "^5.0.1"
+    "tape": "^5.0.1",
+    "typescript": "^4.3.5"
   },
   "engines": {
     "node": ">=10.12.0"

--- a/test/api.js
+++ b/test/api.js
@@ -43,7 +43,7 @@ test('api: lintTextSync', function (t) {
 test('api: parseOpts -- avoid self.eslintConfig parser mutation', function (t) {
   t.plan(2)
   const standard = getStandard()
-  const opts = standard.parseOpts({ parser: 'blah' })
+  const opts = standard.resolveEslintConfig({ parser: 'blah' })
   t.equal(opts.parser, 'blah')
   t.equal(standard.eslintConfig.parser, undefined)
 })
@@ -51,7 +51,7 @@ test('api: parseOpts -- avoid self.eslintConfig parser mutation', function (t) {
 test('api: parseOpts -- avoid self.eslintConfig global mutation', function (t) {
   t.plan(2)
   const standard = getStandard()
-  const opts = standard.parseOpts({ globals: ['what'] })
+  const opts = standard.resolveEslintConfig({ globals: ['what'] })
   t.deepEqual(opts.globals, ['what'])
   t.deepEqual(standard.eslintConfig.globals, [])
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "@tsconfig/node10/tsconfig.json",
+  "files": [
+    "index.js",
+  ],
+  "include": [
+    "bin/**/*.js",
+    "lib/**/*.js",
+  ],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+
+    /* New checks being tried out */
+    "noUncheckedIndexedAccess": true,
+
+    /* Additional checks */
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+  },
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,5 @@
     "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,15 +8,15 @@
     "lib/**/*.js",
   ],
   "compilerOptions": {
+    /* Configures it for targeting javascript */
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
 
-    /* New checks being tried out */
+    /* Adds additional checks beyond "strict": true  */
     "noUncheckedIndexedAccess": true,
-
-    /* Additional checks */
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+
   },
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Other, please explain: To make #234 simpler to solve

**What changes did you make? (Give an overview)**

The main changes:

1. I extended the JSDoc types + added a validation of them using the TypeScript cli utility – this to better ensure that the public API contract doesn't get broken when I, @Divlo or someone else new to the code contributes.
2. In the process of adding the types I found that `parseOpts()` was a bit all over the place and unlike its name was actually mainly focused on simply constructing the needed ESLint Config. I therefore revamped it to be fully focused on that + extracted it into a file of its own to make both it and the main file shorter and more focused.
3. As a result of the revamping of `parseOpts()` and adding types, the custom `parseOpts` argument added in #146 also had to get a modification to it (or be removed – I searched through the entirety of GitHub and there's no public usage there of it at least). I replaced it with a new `resolveEslintConfig` argument which mimics the original one.

**Is there anything you'd like reviewers to focus on?**

- [x] Whether the general approach is good and where we want to take this
- [ ] Actually test this with `standard` itself

**Why is this a draft PR?**

I haven't actually pulled in this version into `standard` itself and tried it there yet, wanted to get this up for some more eyes first, as eg. @Divlo has been working in this area as well.