### PR TITLE
chore: drop support for Node.js v10

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.20.0, 14.13.1, 16.0.0]
       fail-fast: false
 
     steps:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.20.0, 14.13.1, 16.0.0]
+        node-version: ['12.20.0', '14.13.1', '16.0.0', 'lts/*']
       fail-fast: false
 
     steps:

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "xdg-basedir": "^4.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node10": "^1.0.8",
+    "@tsconfig/node12": "^1.0.9",
     "@types/eslint": "^7.28.0",
     "@types/minimist": "^1.2.2",
-    "@types/node": "^10.17.60",
+    "@types/node": "^16.9.1",
     "cross-spawn": "^7.0.3",
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.0",
@@ -61,7 +61,7 @@
     "typescript": "^4.3.5"
   },
   "engines": {
-    "node": ">=10.12.0"
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "funding": [
     {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tsconfig/node12": "^1.0.9",
     "@types/eslint": "^7.28.0",
     "@types/minimist": "^1.2.2",
-    "@types/node": "^16.9.1",
+    "@types/node": "~12.20.0",
     "cross-spawn": "^7.0.3",
     "eslint": "^7.12.1",
     "eslint-config-standard": "^16.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node10/tsconfig.json",
+  "extends": "@tsconfig/node12/tsconfig.json",
   "files": [
     "index.js",
   ],


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- [x] Drop support for Node.js v10
- [x] Add Node.js v16 to the `node-version` matrix in CI with GitHub Actions

**Is there anything you'd like reviewers to focus on?**

BREAKING CHANGE: Minimum supported Node.js version >= 12.0.0