### PR TITLE
feat: usage of ES6 class syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Create the files below and fill in your own values for `options.js`.
 
 ```js
 // programmatic usage
-var Linter = require('standard-engine').linter
-var opts = require('./options.js')
+const { Linter } = require('standard-engine')
+const opts = require('./options.js')
 module.exports = new Linter(opts)
 ```
 
@@ -52,16 +52,17 @@ module.exports = new Linter(opts)
 ```js
 #!/usr/bin/env node
 
-var opts = require('../options.js')
+const opts = require('../options.js')
+
 require('standard-engine').cli(opts)
 ```
 
 ### `options.js`
 
 ```js
-var eslint = require('eslint')
-var path = require('path')
-var pkg = require('./package.json')
+const eslint = require('eslint')
+const path = require('path')
+const pkg = require('./package.json')
 
 module.exports = {
   // homepage, version and bugs pulled from package.json
@@ -78,7 +79,7 @@ module.exports = {
 }
 ```
 
-Additionally an optional `parseOpts()` function can be provided. See below for details.
+Additionally an optional `resolveEslintConfig()` function can be provided. See below for details.
 
 ### `eslintrc.json`
 
@@ -164,7 +165,7 @@ a `ignore` property to `package.json`:
 Some files are ignored by default:
 
 ```js
-var DEFAULT_IGNORE = [
+const DEFAULT_IGNORE = [
   '*.min.js',
   'coverage/',
   'node_modules/',
@@ -270,9 +271,9 @@ install `babel-eslint` globally with `npm install babel-eslint -g`.
 You can provide a `resolveEslintConfig()` function in the `options.js` exports:
 
 ```js
-var eslint = require('eslint')
-var path = require('path')
-var pkg = require('./package.json')
+const eslint = require('eslint')
+const path = require('path')
+const pkg = require('./package.json')
 
 module.exports = {
   // homepage, version and bugs pulled from package.json
@@ -330,7 +331,7 @@ The `callback` will be called with an `Error` and `results` object.
 The `results` object will contain the following properties:
 
 ```js
-var results = {
+const results = {
   results: [
     {
       filePath: '',

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
 
-module.exports = Cli
-
 const minimist = require('minimist')
 const getStdin = require('get-stdin')
 
 /**
  * @typedef StandardCliOptions
- * @property {import('../').linter} [linter]
+ * @property {import('../').Linter} [linter]
  * @property {string} [cmd]
  * @property {string} [tagline]
  * @property {string} [homepage]
@@ -17,7 +15,7 @@ const getStdin = require('get-stdin')
 /**
  * @param {Omit<import('../').LinterOptions, 'cmd'> & StandardCliOptions} rawOpts
  */
-function Cli (rawOpts) {
+function cli (rawOpts) {
   const opts = {
     cmd: 'standard-engine',
     tagline: 'JavaScript Custom Style',
@@ -25,7 +23,7 @@ function Cli (rawOpts) {
     ...rawOpts
   }
 
-  const Linter = require('../').linter
+  const { Linter } = require('../')
   const standard = rawOpts.linter || new Linter(opts)
 
   const argv = minimist(process.argv.slice(2), {
@@ -210,3 +208,5 @@ Flags (advanced):
     }
   }
 }
+
+module.exports = cli

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -23,8 +23,7 @@ function cli (rawOpts) {
     ...rawOpts
   }
 
-  const { Linter } = require('../')
-  const standard = rawOpts.linter || new Linter(opts)
+  const standard = rawOpts.linter || new (require('../').Linter)(opts)
 
   const argv = minimist(process.argv.slice(2), {
     alias: {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 /*! standard-engine. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
-module.exports.cli = require('./bin/cmd')
-
-module.exports.linter = Linter
 
 const os = require('os')
 const path = require('path')
@@ -24,128 +21,134 @@ const { resolveEslintConfig } = require('./lib/resolve-eslint-config')
  * @property {string} [version]
  */
 
-/**
- * @param {LinterOptions} opts
- */
-function Linter (opts) {
-  if (!(this instanceof Linter)) return new Linter(opts)
+class Linter {
+  /**
+   * @param {LinterOptions} opts
+   */
+  constructor (opts) {
+    if (!opts || !opts.cmd) throw new Error('opts.cmd option is required')
+    if (!opts.eslint) throw new Error('opts.eslint option is required')
 
-  if (!opts || !opts.cmd) throw new Error('opts.cmd option is required')
-  if (!opts.eslint) throw new Error('opts.eslint option is required')
+    /** @type {string} */
+    this.cmd = opts.cmd
+    /** @type {import('eslint')} */
+    this.eslint = opts.eslint
+    /** @type {string} */
+    this.cwd = opts.cwd || process.cwd()
+    this.customEslintConfigResolver = opts.resolveEslintConfig
 
-  /** @type {string} */
-  this.cmd = opts.cmd
-  /** @type {import('eslint')} */
-  this.eslint = opts.eslint
-  /** @type {string} */
-  this.cwd = opts.cwd || process.cwd()
-  this.customEslintConfigResolver = opts.resolveEslintConfig
+    const m = opts.version && opts.version.match(/^(\d+)\./)
+    const majorVersion = (m && m[1]) || '0'
 
-  const m = opts.version && opts.version.match(/^(\d+)\./)
-  const majorVersion = (m && m[1]) || '0'
+    // Example cache location: ~/.cache/standard/v12/
+    const cacheLocation = path.join(CACHE_HOME, this.cmd, `v${majorVersion}/`)
 
-  // Example cache location: ~/.cache/standard/v12/
-  const cacheLocation = path.join(CACHE_HOME, this.cmd, `v${majorVersion}/`)
+    /** @type {CLIEngineOptions} */
+    this.eslintConfig = {
+      cache: true,
+      cacheLocation,
+      envs: [],
+      fix: false,
+      globals: [],
+      plugins: [],
+      ignorePattern: [],
+      extensions: [],
+      useEslintrc: false,
+      ...(opts.eslintConfig || {})
+    }
 
-  /** @type {CLIEngineOptions} */
-  this.eslintConfig = {
-    cache: true,
-    cacheLocation,
-    envs: [],
-    fix: false,
-    globals: [],
-    plugins: [],
-    ignorePattern: [],
-    extensions: [],
-    useEslintrc: false,
-    ...(opts.eslintConfig || {})
+    if (this.eslintConfig.configFile != null) {
+      this.eslintConfig.resolvePluginsRelativeTo = path.dirname(
+        this.eslintConfig.configFile
+      )
+    }
   }
 
-  if (this.eslintConfig.configFile != null) {
-    this.eslintConfig.resolvePluginsRelativeTo =
-      path.dirname(this.eslintConfig.configFile)
+  /**
+   * Lint text to enforce JavaScript Style.
+   *
+   * @param {string} text file text to lint
+   * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
+   * @returns {import('eslint').CLIEngine.LintReport}
+   */
+  lintTextSync (text, opts) {
+    const eslintConfig = this.resolveEslintConfig(opts)
+    const engine = new this.eslint.CLIEngine(eslintConfig)
+    return engine.executeOnText(text, (opts || {}).filename)
+  }
+
+  /**
+   * Lint text to enforce JavaScript Style.
+   *
+   * @param {string} text file text to lint
+   * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
+   * @param {LinterCallback} [cb]
+   * @returns {void}
+   */
+  lintText (text, opts, cb) {
+    if (typeof opts === 'function') return this.lintText(text, undefined, opts)
+    if (!cb) throw new Error('callback is required')
+
+    let result
+    try {
+      result = this.lintTextSync(text, opts)
+    } catch (err) {
+      return process.nextTick(cb, err)
+    }
+    process.nextTick(cb, null, result)
+  }
+
+  /**
+   * Lint files to enforce JavaScript Style.
+   *
+   * @param {Array.<string>} files          file globs to lint
+   * @param {BaseLintOptions & { cwd?: string }} [opts] base options + file globs to ignore (has sane defaults) + current working directory (default: process.cwd())
+   * @param {LinterCallback} [cb]
+   * @returns {void}
+   */
+  lintFiles (files, opts, cb) {
+    if (typeof opts === 'function') { return this.lintFiles(files, undefined, opts) }
+    if (!cb) throw new Error('callback is required')
+
+    const eslintConfig = this.resolveEslintConfig(opts)
+
+    if (typeof files === 'string') files = [files]
+    if (files.length === 0) files = ['.']
+
+    let result
+    try {
+      result = new this.eslint.CLIEngine(eslintConfig).executeOnFiles(files)
+    } catch (err) {
+      return cb(err)
+    }
+
+    if (eslintConfig.fix) {
+      this.eslint.CLIEngine.outputFixes(result)
+    }
+
+    return cb(null, result)
+  }
+
+  /**
+   * @param {BaseLintOptions & { cwd?: string }} [opts]
+   * @returns {CLIEngineOptions}
+   */
+  resolveEslintConfig (opts) {
+    const eslintConfig = resolveEslintConfig(
+      {
+        cwd: this.cwd,
+        ...opts,
+        cmd: this.cmd
+      },
+      this.eslintConfig,
+      this.customEslintConfigResolver
+    )
+
+    return eslintConfig
   }
 }
 
-/**
- * Lint text to enforce JavaScript Style.
- *
- * @param {string} text file text to lint
- * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
- * @returns {import('eslint').CLIEngine.LintReport}
- */
-Linter.prototype.lintTextSync = function (text, opts) {
-  const eslintConfig = this.resolveEslintConfig(opts)
-  const engine = new this.eslint.CLIEngine(eslintConfig)
-  return engine.executeOnText(text, (opts || {}).filename)
-}
-
-/**
- * Lint text to enforce JavaScript Style.
- *
- * @param {string} text file text to lint
- * @param {Omit<BaseLintOptions, 'ignore'|'noDefaultIgnore'> & { filename?: string }} [opts] base options + path of file containing the text being linted
- * @param {LinterCallback} [cb]
- * @returns {void}
- */
-Linter.prototype.lintText = function (text, opts, cb) {
-  if (typeof opts === 'function') return this.lintText(text, undefined, opts)
-  if (!cb) throw new Error('callback is required')
-
-  let result
-  try {
-    result = this.lintTextSync(text, opts)
-  } catch (err) {
-    return process.nextTick(cb, err)
-  }
-  process.nextTick(cb, null, result)
-}
-
-/**
- * Lint files to enforce JavaScript Style.
- *
- * @param {Array.<string>} files          file globs to lint
- * @param {BaseLintOptions & { cwd?: string }} [opts] base options + file globs to ignore (has sane defaults) + current working directory (default: process.cwd())
- * @param {LinterCallback} [cb]
- * @returns {void}
- */
-Linter.prototype.lintFiles = function (files, opts, cb) {
-  if (typeof opts === 'function') return this.lintFiles(files, undefined, opts)
-  if (!cb) throw new Error('callback is required')
-
-  const eslintConfig = this.resolveEslintConfig(opts)
-
-  if (typeof files === 'string') files = [files]
-  if (files.length === 0) files = ['.']
-
-  let result
-  try {
-    result = new this.eslint.CLIEngine(eslintConfig).executeOnFiles(files)
-  } catch (err) {
-    return cb(err)
-  }
-
-  if (eslintConfig.fix) {
-    this.eslint.CLIEngine.outputFixes(result)
-  }
-
-  return cb(null, result)
-}
-
-/**
- * @param {BaseLintOptions & { cwd?: string }} [opts]
- * @returns {CLIEngineOptions}
- */
-Linter.prototype.resolveEslintConfig = function (opts) {
-  const eslintConfig = resolveEslintConfig(
-    {
-      cwd: this.cwd,
-      ...opts,
-      cmd: this.cmd
-    },
-    this.eslintConfig,
-    this.customEslintConfigResolver
-  )
-
-  return eslintConfig
+module.exports = {
+  cli: require('./bin/cmd'),
+  Linter
 }

--- a/index.js
+++ b/index.js
@@ -148,7 +148,5 @@ class Linter {
   }
 }
 
-module.exports = {
-  cli: require('./bin/cmd'),
-  Linter
-}
+module.exports.cli = require('./bin/cmd')
+module.exports.Linter = Linter

--- a/test/api.js
+++ b/test/api.js
@@ -1,7 +1,8 @@
 const eslint = require('eslint')
-const Linter = require('../').linter
 const path = require('path')
 const test = require('tape')
+
+const { Linter } = require('../')
 
 function getStandard () {
   return new Linter({
@@ -40,7 +41,7 @@ test('api: lintTextSync', function (t) {
   t.equal(result.errorCount, 1, 'should have used single quotes')
 })
 
-test('api: parseOpts -- avoid self.eslintConfig parser mutation', function (t) {
+test('api: resolveEslintConfig -- avoid this.eslintConfig parser mutation', function (t) {
   t.plan(2)
   const standard = getStandard()
   const opts = standard.resolveEslintConfig({ parser: 'blah' })
@@ -48,7 +49,7 @@ test('api: parseOpts -- avoid self.eslintConfig parser mutation', function (t) {
   t.equal(standard.eslintConfig.parser, undefined)
 })
 
-test('api: parseOpts -- avoid self.eslintConfig global mutation', function (t) {
+test('api: resolveEslintConfig -- avoid this.eslintConfig global mutation', function (t) {
   t.plan(2)
   const standard = getStandard()
   const opts = standard.resolveEslintConfig({ globals: ['what'] })

--- a/test/lib/standard-cmd.js
+++ b/test/lib/standard-cmd.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const path = require('path')
 const eslint = require('eslint')
+
 const opts = {
   cmd: 'pocketlint',
   version: '0.0.0',


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[x] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

- [x] Convert `var` into `let/const` in `README`
- [x] Update `parseOpts` references in tests and `README` to the new `resolveEslintConfig` function introduced in #248
- [x] Convert the `Linter` function constructor to [ES6 class syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/class)
- [x] Better respect the JavaScript camelCase/PascalCase notation, by exporting the `Linter` class as PascalCase instead of camelCase

Before:
```js
const { linter } = require('standard-engine')
```

After:
```js
const { Linter } = require('standard-engine')
```

**Which issue (if any) does this pull request address?**

Fixes #250 

**Is there anything you'd like reviewers to focus on?**

**BREAKING CHANGES** introduced by this PR:

- Export is now called `Linter`, not `linter`
- Calling `Linter()` instead of `new Linter()` doesn't work anymore.