### PR TITLE
Require TypeScript 4.3 until we update

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react": "^7.21.5",
     "standard": "*",
     "tape": "^5.0.1",
-    "typescript": "^4.3.5"
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">=10.12.0"


### PR DESCRIPTION
As the minor versions of TypeScript can cause type issues and 4.4 currently does here

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

I locked the minor version of our typescript dev-dependency

**Which issue (if any) does this pull request address?**

It ensures that we don't get premature errors from an upgrade to eg. typescript 4.4, which we currently are getting, making for a poor contributor experience:

![Skärmavbild 2021-09-07 kl  19 19 21](https://user-images.githubusercontent.com/34457/132385448-28ee920d-92af-4589-a61f-ec968ac289a2.png)

**Is there anything you'd like reviewers to focus on?**

Not really