### PR TITLE
fix(cli): warning message mention homepage

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -141,10 +141,11 @@ Flags (advanced):
     })
 
     if (isSomeWarnings) {
+      const homepage = opts.homepage != null ? ` (${opts.homepage})` : ''
       console.error(
         '%s: %s',
         opts.cmd,
-        'Some warnings are present which will be errors in the next version'
+        `Some warnings are present which will be errors in the next version${homepage}`
       )
     }
 

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -144,7 +144,7 @@ Flags (advanced):
       console.error(
         '%s: %s',
         opts.cmd,
-        'Some warnings are present which will be errors in the next version (https://standardjs.com'
+        'Some warnings are present which will be errors in the next version'
       )
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

`standard-engine` is being used not only for `standard` itself but also for other engines like [ts-standard](https://github.com/toddbluhm/ts-standard), [happiness](https://github.com/JedWatson/happiness), etc.

That being said, it makes sense to not include specific things related to `standard` only.
This PR remove the mention of [standardjs.com](https://standardjs.com) in a warning message.

