### PR TITLE
lintFiles() to await on ESLint.outputFixes()

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ class StandardEngine {
     const result = await eslintInstance.lintFiles(files)
 
     if (eslintConfig.fix) {
-      this.eslint.ESLint.outputFixes(result)
+      await this.eslint.ESLint.outputFixes(result)
     }
 
     return result


### PR DESCRIPTION
This ensures that fixes are written before resolving.

Without this, the file may be in a weird state if consumed right after calling `lintFiles()` (e.g. reading the files right after calling `lintFiles()` would return an empty string, stat would show a zero-sized file).

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Added `await` to `this.eslint.ESLint.outputFixes(result)` to ensure the fixed files are written before `lintFiles()` returns.

Under the hood, [`ESLint.outputFixes()`](https://github.com/eslint/eslint/blob/v8.13.0/lib/eslint/eslint.js#L472) is an async function that awaits on a promisified `fs.writeFile()`. 

**Which issue (if any) does this pull request address?**

None.

**Is there anything you'd like reviewers to focus on?**

Cross-platform testing. Issue may be OS-dependent because it deals with the filesystem. This issue happened on a Windows machine, I cannot verify on other platforms. 
